### PR TITLE
Fixed error handling of scripts task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,11 +51,11 @@ gulp.task('scripts', function() {
   .transform(babelify);
 
   return b.bundle()
+  .on('error', $$.notify.onError("Error: <%= error.message %>"))
+  .on('error', handleError)
   .pipe(source('bundle.js'))
   .pipe(buffer())
   .pipe($$.sourcemaps.init({loadMaps: true}))
-  .on('error', $$.notify.onError("Error: <%= error.message %>"))
-  .on('error', handleError)
   .pipe($$.uglify())
   .pipe($$.sourcemaps.write('./'))
   .pipe(gulp.dest(distFolder.js))


### PR DESCRIPTION
Upon first run, if there was any error in JS file, gulp was exiting miserably, I run some test and finally fix it by moving `.on error` event up just after `bundle()`.